### PR TITLE
공통 응답 모델 구현

### DIFF
--- a/src/main/java/com/kyonggi/teampu/global/response/ApiResponse.java
+++ b/src/main/java/com/kyonggi/teampu/global/response/ApiResponse.java
@@ -1,0 +1,46 @@
+package com.kyonggi.teampu.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private Status status;
+
+    private Metadata metadata;
+
+    private List<T> results;
+
+    public static <T> ApiResponse<T> ok(List<T> results) {
+        return new ApiResponse<>(
+                new Status(HttpStatus.OK, "OK"),
+                new Metadata(results.size()),
+                results
+        );
+    }
+
+    public static <T> ApiResponse<T> ok(T body) {
+        return new ApiResponse<>(
+                new Status(HttpStatus.OK, "OK"),
+                new Metadata(1),
+                List.of(body)
+        );
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class Metadata {
+        private int resultCount = 0;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class Status {
+        private HttpStatus httpStatus;
+        private String message;
+    }
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈

#12 

### 📝 작업 내용

- 공통 응답 모델을 구현했습니다.
  - API에서 반환할 body, body 관련 메타 데이터, Http Status 관련 정보를 관리합니다.
  - 에외 또한 해당 믕답 모델을 통해 반환해야 하는데, 아직 예외 쪽 기능을 만들지 않아서 만들고 추가하도록 하겠습니다.

### 📷 스크린샷 (선택)

다음과 같이 사용합니다.
```java
@GetMapping("/test")
    public ApiResponse<String> test() {
        return ApiResponse.ok("Hello, world!");
    }
```

```json
{
    "status": {
        "httpStatus": "OK",
        "message": "OK"
    },
    "metadata": {
        "resultCount": 1
    },
    "results": [
        "Hello, world!"
    ]
}
```

### 💬 리뷰 요구사항 (선택)