### PR TITLE
야간잔류 삭제 기능 구현

### DIFF
--- a/src/main/java/com/kyonggi/teampu/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/kyonggi/teampu/domain/application/controller/ApplicationController.java
@@ -1,15 +1,14 @@
 package com.kyonggi.teampu.domain.application.controller;
 
+import com.kyonggi.teampu.domain.application.domain.Application;
 import com.kyonggi.teampu.domain.application.dto.ApplicationRequest;
+import com.kyonggi.teampu.domain.application.repository.ApplicationRepository;
 import com.kyonggi.teampu.domain.application.service.ApplicationService;
 import com.kyonggi.teampu.domain.auth.domain.CustomMemberDetails;
 import com.kyonggi.teampu.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,6 +27,15 @@ public class ApplicationController {
         applicationService.createApplication(applicationRequest, customMemberDetails);
 
         return ApiResponse.ok(); // POST에 대해서 리턴 값 필요없음 >> Void
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteApplication(@PathVariable Long id,
+                                               @AuthenticationPrincipal CustomMemberDetails customMemberDetails) {
+
+        applicationService.deleteApplication(id, customMemberDetails);
+
+        return ApiResponse.ok();
     }
 
 }

--- a/src/main/java/com/kyonggi/teampu/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/kyonggi/teampu/domain/application/controller/ApplicationController.java
@@ -1,8 +1,6 @@
 package com.kyonggi.teampu.domain.application.controller;
 
-import com.kyonggi.teampu.domain.application.domain.Application;
 import com.kyonggi.teampu.domain.application.dto.ApplicationRequest;
-import com.kyonggi.teampu.domain.application.repository.ApplicationRepository;
 import com.kyonggi.teampu.domain.application.service.ApplicationService;
 import com.kyonggi.teampu.domain.auth.domain.CustomMemberDetails;
 import com.kyonggi.teampu.global.response.ApiResponse;

--- a/src/main/java/com/kyonggi/teampu/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/kyonggi/teampu/domain/application/service/ApplicationService.java
@@ -59,4 +59,5 @@ public class ApplicationService {
 
         applicationRepository.delete(application);
     }
+
 }

--- a/src/main/java/com/kyonggi/teampu/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/kyonggi/teampu/domain/application/service/ApplicationService.java
@@ -51,4 +51,12 @@ public class ApplicationService {
         applicationRepository.save(application);
     }
 
+
+    @Transactional
+    public void deleteApplication(Long id, CustomMemberDetails customMemberDetails){
+        Application application = applicationRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("신청서를 찾을 수 없습니다."));
+
+        applicationRepository.delete(application);
+    }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

#34

### 📝 작업 내용

- 사용자의 정보를 토큰으로 받아왔습니다.
- application의 Id를 이용해서 해당 야간잔류를 삭제하는 API를 구현했습니다.

### 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/feae2c81-2189-446d-b49c-f755e20062f0)


### 💬 리뷰 요구사항 (선택)

야간잔류 신청 구현 PR (#26) 이 아직 Merge 되지 않아서 해당 브랜치에서 pull 하고 delete만 구현했습니다.
feature 브랜치끼리 pull 하면 좀 꼬일 수 있을 것 같네요
나머지 기능은 Merge 후에 구현하겠습니다🫡

develop 브랜치에서 pull 받아 최신화하고 Merge 하겠습니다! 

문제 생기면 말씀해주세요!!