### PR TITLE
야간잔류 상세 조회 기능 구현 

### DIFF
--- a/src/main/java/com/kyonggi/teampu/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/kyonggi/teampu/domain/application/controller/ApplicationController.java
@@ -1,6 +1,7 @@
 package com.kyonggi.teampu.domain.application.controller;
 
 import com.kyonggi.teampu.domain.application.dto.ApplicationRequest;
+import com.kyonggi.teampu.domain.application.dto.ApplicationResponse;
 import com.kyonggi.teampu.domain.application.service.ApplicationService;
 import com.kyonggi.teampu.domain.auth.domain.CustomMemberDetails;
 import com.kyonggi.teampu.global.response.ApiResponse;
@@ -35,5 +36,16 @@ public class ApplicationController {
 
         return ApiResponse.ok();
     }
+
+    @GetMapping("/{id}")
+    public ApiResponse<ApplicationResponse> getDetailApplication(@PathVariable Long id,
+                                                                 @AuthenticationPrincipal CustomMemberDetails customMemberDetails){
+        ApplicationResponse applicationResponse = applicationService.getDetailApplication(id, customMemberDetails);
+
+        return ApiResponse.ok(applicationResponse);
+    }
+
+
+
 
 }

--- a/src/main/java/com/kyonggi/teampu/domain/application/domain/Application.java
+++ b/src/main/java/com/kyonggi/teampu/domain/application/domain/Application.java
@@ -30,7 +30,7 @@ public class Application {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
-    private ApplicationStatus status;
+    private ApplicationStatus status = ApplicationStatus.PENDING; // 기본값 설정
 
     @Column(name = "participant_count")
     private Integer participantCount;

--- a/src/main/java/com/kyonggi/teampu/domain/application/dto/ApplicationResponse.java
+++ b/src/main/java/com/kyonggi/teampu/domain/application/dto/ApplicationResponse.java
@@ -1,0 +1,25 @@
+package com.kyonggi.teampu.domain.application.dto;
+
+
+import com.kyonggi.teampu.domain.application.domain.Application;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class ApplicationResponse {
+    private LocalDate appliedDate; // 날짜
+    private String name; // 이름
+    private Integer participantCount; // 참여 인원(신청자 제외)
+
+    public static ApplicationResponse fromEntity(Application application){
+        return ApplicationResponse.builder()
+                .appliedDate(application.getAppliedDate()) // 날짜
+                .name(application.getMember().getName()) // 이름
+                .participantCount(application.getCoParticipants().size()) // 참여 인원(신청자 제외)
+                .build();
+    }
+
+}

--- a/src/main/java/com/kyonggi/teampu/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/kyonggi/teampu/domain/application/service/ApplicationService.java
@@ -2,6 +2,7 @@ package com.kyonggi.teampu.domain.application.service;
 
 import com.kyonggi.teampu.domain.application.domain.Application;
 import com.kyonggi.teampu.domain.application.dto.ApplicationRequest;
+import com.kyonggi.teampu.domain.application.dto.ApplicationResponse;
 import com.kyonggi.teampu.domain.application.repository.ApplicationRepository;
 import com.kyonggi.teampu.domain.auth.domain.CustomMemberDetails;
 import com.kyonggi.teampu.domain.member.domain.CoParticipant;
@@ -12,6 +13,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.kyonggi.teampu.domain.application.dto.ApplicationResponse.fromEntity;
 
 @Service
 @RequiredArgsConstructor
@@ -60,4 +63,12 @@ public class ApplicationService {
         applicationRepository.delete(application);
     }
 
+    @Transactional
+    public ApplicationResponse getDetailApplication(Long id, CustomMemberDetails customMemberDetails){
+        Application application = applicationRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("신청서를 찾을 수 없습니다."));
+
+        return fromEntity(application);
+
+    }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

#36

### 📝 작업 내용

- 사용자의 정보를 토큰으로 받아왔습니다.
- application의 Id를 이용해서 해당 야간잔류를 상세 조회하는 API를 구현했습니다.
- ApplicationResponse 응답 DTO를 구현했습니다.
- 참여 인원의 경우, 신청자를 제외해서 나타냈습니다.

### 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f9cb677e-38eb-44b8-bdaa-f60a8161763a)


### 💬 리뷰 요구사항 (선택)
- 코드가 통일성이 없는 것 같아서 추후 리팩토링 해보겠습니다! 😳
- 피그마에서는 시작 시간 ~ 종료 시간이 나와있는데,
 일단 이 부분은 17:00 ~ 22:00로 고정하기로 해서 따로 구현하지 않았습니다.