### PR TITLE
야간잔류 수정 기능 구현

### DIFF
--- a/src/main/java/com/kyonggi/teampu/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/kyonggi/teampu/domain/application/controller/ApplicationController.java
@@ -45,7 +45,12 @@ public class ApplicationController {
         return ApiResponse.ok(applicationResponse);
     }
 
-
-
+    @PatchMapping("/{id}")
+    public ApiResponse<Void> updateApplication(@PathVariable Long id,
+                                                              @AuthenticationPrincipal CustomMemberDetails customMemberDetails,
+                                                              @RequestBody ApplicationRequest applicationRequest){
+        applicationService.updateApplication(id, customMemberDetails, applicationRequest);
+        return ApiResponse.ok();
+    }
 
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

#38

### 📝 작업 내용

- 사용자의 정보를 토큰으로 받아왔습니다.
- application의 Id를 이용해서 해당 야간잔류를 수정하는 API를 구현했습니다.

### 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/5335a6b8-9cc2-47d7-8174-9d867db35fc8)


![image](https://github.com/user-attachments/assets/dbd4698e-9426-4ff0-8b63-bd71b60a601f)
위처럼 신청서를 신청하고, 

![image](https://github.com/user-attachments/assets/38996837-0d53-4816-9409-39aaa9c714ac)
신청서를 수정할 수 있습니다.

### 💬 리뷰 요구사항 (선택)

participant_count 변수가 신청자 포함이랑 신청자 제외를 나타내는데 모두 사용되어서 헷갈릴 수 있을 것 같습니다. 
별도의 계산 없이 하나로 통일하거나, application_co_participants 테이블에 별도 컬럼으로 만들어야 할 것 같습니다. 

코드 리팩토링 하겠습니다.☺️