### PR TITLE
Run Database Migration에서 gradle 버전 명시

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Setup Gradle # gradle 셋업
         uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: current
 
       - name: DB secret capture
         run: |


### PR DESCRIPTION
### #️⃣ 연관된 이슈

#70

### 📝 작업 내용

Java 11 관련 오류로 Gradle이 Java 17을 사용하여 빌드를 수행하도록 gradle-version을 추가했습니다.

### 📷 스크린샷 (선택)

### 💬 리뷰 요구사항 (선택)